### PR TITLE
Fix running issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'devise'
 
 gem 'autoprefixer-rails'
 gem 'cloudinary', '~> 1.16.0'
-gem 'dotenv-rails', groups: [:development, :test]
+# gem 'dotenv-rails', groups: [:development, :test]
 gem 'font-awesome-sass'
 gem 'faker'
 gem 'pg_search', '~> 2.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)


### PR DESCRIPTION
commented out duplicate of dotenv gem  on line 35 of gemfile (so when bundle install is run, the dotenv duplicate is not mentioned anymore), updated mimemagic. 

Therefore,
As long as
```bundle install``` 
is entered, developer is running node version 14 (node -v command to check, nvm use 14 to change to node version 14 if necessary),
```yarn install --check-files```
is entered, developer should be able to type 
```rails server```

in case of proxy issues (long lines of gyp errors) please enter:

```
yarn config set proxy '' &&
yarn config set https-proxy ''
```
to undo proxy and run
```rails server```
again

app should be running with rails server

Thanks and apologize if somehow things still go wrong

Best,

Sho